### PR TITLE
CSHARP-2102: Reduce Evergreen matrix size

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -453,8 +453,15 @@ buildvariants:
   tasks:
     - name: compile
 
-- matrix_name: "tests"
-  matrix_spec: { version: "*", topology: "*", auth: "*", ssl: "*", os: "*" }
+- matrix_name: "secure-tests"
+  matrix_spec: { version: "*", topology: "*", auth: "auth", ssl: "ssl", os: "*" }
+  display_name: "${version} ${topology} ${auth} ${ssl} ${os}"
+  tags: ["tests-variant"]
+  tasks:
+     - name: test
+
+- matrix_name: "unsecure-tests"
+  matrix_spec: { version: "*", topology: "*", auth: "noauth", ssl: "nossl", os: "*" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${os}"
   tags: ["tests-variant"]
   tasks:


### PR DESCRIPTION
Instead of testing all combinations of ssl and auth (four), just test (noauth, nossl) and (auth,ssl).

Patch build: https://evergreen.mongodb.com/version/5bad22fee3c3317b5a838cbc